### PR TITLE
Change redis test to check for bytestring

### DIFF
--- a/lti.py
+++ b/lti.py
@@ -125,7 +125,7 @@ def status():  # pragma:nocover
     # Check redis
     try:
         response = app.conn.echo("test")
-        status["checks"]["redis"] = response == "test"
+        status["checks"]["redis"] = response == b"test"
     except ConnectionError:
         app.logger.exception("Redis connection failed.")
 


### PR DESCRIPTION
Fixes an issue where the `"redis"` check on `status()` would always return `false`