### PR TITLE
AJAX test fix

### DIFF
--- a/lti.py
+++ b/lti.py
@@ -32,9 +32,7 @@ app.config.from_object("config")
 
 formatter = logging.Formatter(LOG_FORMAT)
 handler = RotatingFileHandler(
-    LOG_FILE,
-    maxBytes=LOG_MAX_BYTES,
-    backupCount=LOG_BACKUP_COUNT,
+    LOG_FILE, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT
 )
 handler.setLevel(logging.getLevelName(LOG_LEVEL))
 handler.setFormatter(formatter)
@@ -66,9 +64,7 @@ def launch(lti=lti):
         )
         return render_template(
             "error.htm.j2",
-            message=msg.format(
-                ", ".join(ALLOWED_CANVAS_DOMAINS), canvas_domain
-            ),
+            message=msg.format(", ".join(ALLOWED_CANVAS_DOMAINS), canvas_domain),
         )
 
     course_id = request.form.get("custom_canvas_course_id")
@@ -82,7 +78,7 @@ def index(lti=lti):
 
 
 @app.route("/status", methods=["GET"])
-def status():
+def status():  # pragma: no cover
     """
     Runs smoke tests and reports status
     """
@@ -187,7 +183,13 @@ def update_assignments(course_id, lti=lti):
             mimetype="application/json",
         )
 
-    if not request.is_xhr:
+    def is_ajax_request(request):
+        """
+        Determine whether or not a request was made via AJAX.
+        """
+        return request.headers.get("X-Ddc-Ajax", "").lower() == "true"
+
+    if not is_ajax_request(request):
         return render_template("error.htm.j2", message="Non-AJAX requests not allowed.")
 
     try:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,6 @@
 coverage run -m unittest discover
 coverage html
 coverage report
+black --check .
 flake8 .
 mdl .

--- a/templates/assignments.htm.j2
+++ b/templates/assignments.htm.j2
@@ -174,22 +174,27 @@
 			var post_url = $(this).attr('action');
 
 			// TODO: only update assignments that are altered.
-
-			$.post(post_url, $(this).serialize(), function(data) {
-
-				var new_text = "<p>" + data.message + "</p>"
-				if (data.updated.length > 0) {
-					new_text += "<table class='table'><thead><tr><th scope='col'>ID</th><th scope='col'>Title</th><th scope='col'>Type</th></tr></thead><tbody>"
-					for (x in data.updated) {
-						new_text += "<tr><td>" + data.updated[x].id + "</td><td>" + data.updated[x].title + "</td><td>" + data.updated[x].type + "</td></tr>";
+			$.ajax({
+				url: post_url,
+				type: 'post',
+				data: $(this).serialize(),
+				headers: {"X-Ddc-Ajax": true},
+				dataType: 'json',
+				success: function(data) {
+					var new_text = "<p>" + data.message + "</p>"
+					if (data.updated.length > 0) {
+						new_text += "<table class='table'><thead><tr><th scope='col'>ID</th><th scope='col'>Title</th><th scope='col'>Type</th></tr></thead><tbody>"
+						for (x in data.updated) {
+							new_text += "<tr><td>" + data.updated[x].id + "</td><td>" + data.updated[x].title + "</td><td>" + data.updated[x].type + "</td></tr>";
+						}
+						new_text += '</tbody></table><div class="alert alert-info" role="alert"><p>Notice:  If an assignment\'s due date is not updating correctly, please make sure that it has been assigned to "Everyone".</p><p>Please contact support if you need any assistance.</p></div>'
 					}
-					new_text += '</tbody></table><div class="alert alert-info" role="alert"><p>Notice:  If an assignment\'s due date is not updating correctly, please make sure that it has been assigned to "Everyone".</p><p>Please contact support if you need any assistance.</p></div>'
+
+					$('#status_content').html(new_text);
+
+					$('#close_button').prop('disabled', false);
+					$('#close_x').show();
 				}
-
-				$('#status_content').html(new_text);
-
-				$('#close_button').prop('disabled', false);
-				$('#close_x').show();
 			});
 		});
 	</script>

--- a/tests.py
+++ b/tests.py
@@ -8,9 +8,9 @@ from six.moves.urllib.parse import urlencode
 
 import lti
 
-try:
+try:  # pragma: no cover
     from unittest.mock import patch  # py3
-except ImportError:
+except ImportError:  # pragma: no cover
     from mock import patch  # py2
 
 
@@ -43,7 +43,7 @@ class LTITests(flask_testing.TestCase):
         self.assert_template_used("lti.xml.j2")
         self.assertIn("application/xml", response.content_type)
 
-    @patch('lti.ALLOWED_CANVAS_DOMAINS', [None])
+    @patch("lti.ALLOWED_CANVAS_DOMAINS", [None])
     def test_launch(self, m):
         payload = {"custom_canvas_course_id": "1"}
 
@@ -250,7 +250,7 @@ class LTITests(flask_testing.TestCase):
 
         payload = {"key": "value"}
         headers = {
-            "X-Requested-With": "XMLHttpRequest",
+            "X-Ddc-Ajax": True,
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
@@ -284,7 +284,7 @@ class LTITests(flask_testing.TestCase):
 
         payload = {"key": "value"}
         headers = {
-            "X-Requested-With": "XMLHttpRequest",
+            "X-Ddc-Ajax": True,
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
@@ -329,7 +329,7 @@ class LTITests(flask_testing.TestCase):
 
         payload = {"42-assignment_type": "assignment", "42-published": False}
         headers = {
-            "X-Requested-With": "XMLHttpRequest",
+            "X-Ddc-Ajax": True,
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
@@ -382,7 +382,7 @@ class LTITests(flask_testing.TestCase):
 
         payload = {"42-assignment_type": "assignment", "42-published": False}
         headers = {
-            "X-Requested-With": "XMLHttpRequest",
+            "X-Ddc-Ajax": True,
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
@@ -459,7 +459,7 @@ class LTITests(flask_testing.TestCase):
             "10-due_at": "01/01/2017 10:00 AM",
         }
         headers = {
-            "X-Requested-With": "XMLHttpRequest",
+            "X-Ddc-Ajax": True,
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
@@ -543,7 +543,7 @@ class LTITests(flask_testing.TestCase):
             "10-due_at": "01/01/2017 10:00 AM",
         }
         headers = {
-            "X-Requested-With": "XMLHttpRequest",
+            "X-Ddc-Ajax": True,
             "Content-Type": "application/x-www-form-urlencoded",
         }
 


### PR DESCRIPTION
- Removed call to deprecated `is_xhr` function.
- Created new header `X-Ddc-Ajax` to send and test for when using ajax
- Switched from using `.post` to `.ajax` to allow sending custom header
- Made coverage ignore a few things we aren't interested in testing
- Formatting tweaks

Resolves #24 